### PR TITLE
CMD list in version string corrected; matches parseCommand().

### DIFF
--- a/Arduino/MEEPROMMERfirmware/MEEPROMMERfirmware.ino
+++ b/Arduino/MEEPROMMERfirmware/MEEPROMMERfirmware.ino
@@ -14,7 +14,7 @@
  *
  **/
 
-#define VERSIONSTRING "MEEPROMMER $Revision: 1.2 $ $Date: 2013/05/05 11:01:54 $, CMD:B,b,w,W,V"
+#define VERSIONSTRING "MEEPROMMER $Revision: 1.2 $ $Date: 2013/05/05 11:01:54 $, CMD:R,r,w,W,V"
 
 // shiftOut part
 #define DS      A0


### PR DESCRIPTION
`parseCommand()` defines commands as:

```
R: READ_HEX
r: READ_BIN
W: WRITE_HEX
w: WRITE_BIN
V: VERSION
```

This patch fixes the command list advertised in the version string to match that list; `R,r,w,W,V`
