### PR TITLE
New 'A,0000' command sets address bus to given value.

### DIFF
--- a/Arduino/MEEPROMMERfirmware/MEEPROMMERfirmware.ino
+++ b/Arduino/MEEPROMMERfirmware/MEEPROMMERfirmware.ino
@@ -58,6 +58,7 @@ unsigned int lineLength,dataLength;
 //define COMMANDS
 #define NOCOMMAND    0
 #define VERSION      1
+#define SET_ADDRESS  2
 
 #define READ_HEX    10
 #define READ_BIN    11
@@ -312,6 +313,9 @@ byte parseCommand() {
   lineLength=hexByte(cmdbuf+12);
   byte retval = 0;
   switch(cmdbuf[0]) {
+  case 'A':
+    retval = SET_ADDRESS;
+    break;
   case 'R':
     retval = READ_HEX;
     break;
@@ -503,6 +507,14 @@ void loop() {
   byte cmd = parseCommand();
   int bytes = 0;
   switch(cmd) {
+  case SET_ADDRESS:
+    // Set the address bus to an arbitrary value.
+    // Useful for debugging shift-register wiring, byte-order.
+    // e.g. A,00FF
+    Serial.print("Setting address bus to 0x");
+    Serial.println(cmdbuf + 2);
+    set_address_bus(startAddress);
+    break;
   case READ_HEX:
     //set a default if needed to prevent infinite loop
     if(lineLength==0) lineLength=32;


### PR DESCRIPTION
Useful for debugging shift-register wiring and the resulting address bus
byte order.

e.g. `A,00FF` should only set A0..A7 high.
