### PR TITLE
Shift high byte of address bus first.

### DIFF
--- a/Arduino/MEEPROMMERfirmware/MEEPROMMERfirmware.ino
+++ b/Arduino/MEEPROMMERfirmware/MEEPROMMERfirmware.ino
@@ -138,9 +138,9 @@ void set_address_bus(unsigned int address)
   bitClear(PORTC,PORTC_LATCH);
 
   //shift out highbyte
-  fastShiftOut(low);
-  //shift out lowbyte
   fastShiftOut(hi);
+  //shift out lowbyte
+  fastShiftOut(low);
 
   //enable latch and set address
   bitSet(PORTC,PORTC_LATCH);


### PR DESCRIPTION
The schematic at http://www.ichbinzustaendig.de/dev/meeprommer-en shows
the low-byte address bus 74HC595 (EEPROM A0..A7) connected first,
cascading into the high-byte 74HC595. This means the high byte should be
shifted first. The code comments reflect this, but the actual code
doesn't.

Note that @presslab-us's fork shifts the high byte first, although he
says he didn't specifically change the address byte order. I'm not sure
how it crept in here - probably while experimenting for a board with
the '595 chips wired in reverse.
